### PR TITLE
Fix PersistentMatcher repr

### DIFF
--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -61,7 +61,7 @@ class PersistentMatcher(Matcher):
         return self._value == other
 
     def __repr__(self) -> str:
-        return f"PersistentMatcher(value={self._value})"
+        return f"PersistentMatcher(value={self._value!r})"
 
 
 mtch = Matcher

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -18,3 +18,9 @@ def test_matcher_keeps_value() -> None:
     user_id = mtch.eq()
     assert {"id": 1, "child": {"id": 2}} != {"id": user_id, "child": {"id": user_id}}
     assert {"id": 1, "child": {"id": 1}} == {"id": user_id, "child": {"id": user_id}}
+
+
+def test_persistent_matcher_repr() -> None:
+    matcher = mtch.eq()
+    assert matcher == "foo"
+    assert repr(matcher) == "PersistentMatcher(value='foo')"


### PR DESCRIPTION
## Summary
- show repr value with quotes in PersistentMatcher
- check PersistentMatcher representation in tests

## Testing
- `pre-commit run --files mtchrs/matchers.py tests/test_matchers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843568a2bc48321886107f3894c7fad