### PR TITLE
Dynamic repr for matchers

### DIFF
--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -5,28 +5,34 @@ import typing as t
 
 
 class Matcher:
-    def __init__(self, func: t.Callable[[t.Any], bool], repr_str: str):
+    def __init__(self, func: t.Callable[[t.Any], bool], repr_func: t.Callable[[], str]):
         self._func = func
-        self._repr_str = repr_str
+        self._repr_func = repr_func
 
     def __eq__(self, other: t.Any) -> bool:
         return self._func(other)
 
     def __and__(self, other: Matcher) -> Matcher:
-        return Matcher(lambda v: self == v and other == v, f"({self}) & ({other})")
+        return Matcher(
+            lambda v: self == v and other == v,
+            lambda: f"({self}) & ({other})",
+        )
 
     def __or__(self, other: "Matcher") -> "Matcher":
-        return Matcher(lambda v: self == v or other == v, f"({self}) | ({other})")
+        return Matcher(
+            lambda v: self == v or other == v,
+            lambda: f"({self}) | ({other})",
+        )
 
     def __repr__(self) -> str:
-        return self._repr_str
+        return self._repr_func()
 
     def __invert__(self) -> Matcher:
-        return Matcher(lambda v: not self._func(v), f"~({self})")
+        return Matcher(lambda v: not self._func(v), lambda: f"~({self})")
 
     @staticmethod
     def any() -> Matcher:
-        return Matcher(lambda v: True, "Any")
+        return Matcher(lambda v: True, lambda: "Any")
 
     @staticmethod
     def eq() -> PersistentMatcher:
@@ -36,7 +42,7 @@ class Matcher:
     def type(*types: type) -> Matcher:
         return Matcher(
             lambda v: isinstance(v, types),
-            f'Type[{" | ".join((str(t) for t in types))}]',
+            lambda: f'Type[{" | ".join((str(t) for t in types))}]',
         )
 
     @staticmethod
@@ -44,7 +50,7 @@ class Matcher:
         compiled = re.compile(pattern) if isinstance(pattern, str) else pattern
         return Matcher(
             lambda v: isinstance(v, str) and bool(compiled.match(v)),
-            f"{compiled}",
+            lambda: f"{compiled}",
         )
 
 
@@ -52,16 +58,13 @@ class PersistentMatcher(Matcher):
     _no_value = object()
 
     def __init__(self):
-        super().__init__(self._func, "PersistentMatcher")
         self._value = self._no_value
+        super().__init__(self._func, lambda: f"PersistentMatcher(value={self._value!r})")
 
     def _func(self, other: t.Any) -> bool:
         if self._value is self._no_value:
             self._value = other
         return self._value == other
-
-    def __repr__(self) -> str:
-        return f"PersistentMatcher(value={self._value!r})"
 
 
 mtch = Matcher

--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -59,7 +59,9 @@ class PersistentMatcher(Matcher):
 
     def __init__(self):
         self._value = self._no_value
-        super().__init__(self._func, lambda: f"PersistentMatcher(value={self._value!r})")
+        super().__init__(
+            self._func, lambda: f"PersistentMatcher(value={self._value!r})"
+        )
 
     def _func(self, other: t.Any) -> bool:
         if self._value is self._no_value:

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -20,6 +20,17 @@ def test_matcher_keeps_value() -> None:
     assert {"id": 1, "child": {"id": 1}} == {"id": user_id, "child": {"id": user_id}}
 
 
+def test_dynamic_repr_with_persistent_matcher() -> None:
+    persistent = mtch.eq()
+    matcher = mtch.type(int) & persistent
+
+    assert matcher == 7
+    assert repr(matcher) == f"(Type[<class 'int'>]) & (PersistentMatcher(value=7))"
+
+    inverted = ~persistent
+    assert repr(inverted) == "~(PersistentMatcher(value=7))"
+
+
 def test_persistent_matcher_repr() -> None:
     matcher = mtch.eq()
     assert matcher == "foo"

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -25,7 +25,7 @@ def test_dynamic_repr_with_persistent_matcher() -> None:
     matcher = mtch.type(int) & persistent
 
     assert matcher == 7
-    assert repr(matcher) == f"(Type[<class 'int'>]) & (PersistentMatcher(value=7))"
+    assert repr(matcher) == "(Type[<class 'int'>]) & (PersistentMatcher(value=7))"
 
     inverted = ~persistent
     assert repr(inverted) == "~(PersistentMatcher(value=7))"


### PR DESCRIPTION
## Summary
- make `Matcher` accept a callable returning the representation
- build dynamic reprs for `__and__`, `__or__`, and `__invert__`
- allow `PersistentMatcher` to update its repr after matching
- test the dynamic repr behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684356804ba483218ab2debf06863066