### PR TITLE
Add MkDocs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,9 @@ name: deploy-docs
 
 on:
   push:
-    branches: [main]
+#    branches: [main]
+  # any branch for testing purposes
+    branches: ['**']
   workflow_dispatch:
 
 permissions:
@@ -16,12 +18,10 @@ jobs:
       - name: Set up Python
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.12'
+          python-version: '3.9'
       - name: Install MkDocs
         run: |
           uv pip install mkdocs mkdocs-material
       - name: Deploy
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: deploy-docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - name: Install MkDocs
+        run: |
+          uv pip install mkdocs mkdocs-material
+      - name: Deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# mtchrs
+
+`mtchrs` provides small, composable matchers for validating values in tests and data structures.
+
+## Installation
+
+```bash
+pip install mtchrs
+```
+
+## Quickstart
+
+```python
+from mtchrs.matchers import mtch
+
+assert mtch.any() == 123
+assert mtch.type(int) == 42
+assert mtch.regex(r"\d+") == "456"
+
+id_matcher = mtch.eq()
+assert {"id": 1, "child": {"id": 1}} == {"id": id_matcher, "child": {"id": id_matcher}}
+```
+
+See the [Usage](usage.md) page for details on available matchers.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,54 @@
+# Usage
+
+This library exposes a simple `Matcher` class and helper constructors via the `mtch` alias.
+
+## `mtch.any`
+
+Matches any value.
+
+```python
+assert mtch.any() == "anything"
+```
+
+## `mtch.type`
+
+Matches when the value is an instance of the provided type or types.
+
+```python
+assert mtch.type(int) == 1
+assert mtch.type(int, float) == 3.14
+```
+
+## `mtch.regex`
+
+Matches a string against a regular expression.
+
+```python
+assert mtch.regex(r"\d+") == "123"
+```
+
+## `mtch.eq`
+
+Creates a persistent matcher that remembers the first value it was compared with and requires subsequent comparisons to match that value.
+
+```python
+m = mtch.eq()
+assert m == "foo"
+assert m == "foo"  # subsequent comparisons must match
+```
+
+## Combining matchers
+
+Matchers support logical operators:
+
+* `&` — logical AND
+* `|` — logical OR
+* `~` — logical NOT
+
+```python
+number = mtch.type(int) | (mtch.type(str) & mtch.regex(r"\d+"))
+assert number == 123
+assert number == "456"
+```
+
+Matchers can also be used inside dictionaries or other containers for nested comparisons.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,20 @@
 site_name: mtchrs
+
 theme:
   name: material
+
+repo_name: angru/mtchrs
 repo_url: https://github.com/angru/mtchrs
+
 nav:
   - Home: index.md
   - Usage: usage.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: mtchrs
+theme:
+  name: material
+repo_url: https://github.com/angru/mtchrs
+nav:
+  - Home: index.md
+  - Usage: usage.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,5 @@ test = [
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.14",
+    "pygments>=2.19.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,7 @@ test = [
     "pytest>=8.4.0",
     "pytest-cov>=6.1.1",
 ]
+docs = [
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.6.14",
+]


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy MkDocs documentation to GitHub Pages

## Testing
- `pytest -q`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68435d3f224c8321801455d453ccec4a