### PR TITLE
Improve matcher tests

### DIFF
--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -1,20 +1,36 @@
+from unittest.mock import Mock, call
+
+
 from mtchrs.matchers import mtch
 
 
-def test_matcher() -> None:
-    assert mtch.any() == 123
+def test_basic_matchers() -> None:
+    assert mtch.any() == "anything"
     assert mtch.type(int, float) == 3.14
-    assert mtch.regex(r"\d+") == "456"
-    assert mtch.type(int) | (mtch.type(str) & mtch.regex(r"\d+")) == 789
-    assert mtch.type(int) | (mtch.type(str) & mtch.regex(r"\d+")) == "789"
+    assert mtch.regex(r"\d+") == "42"
 
-    assert {"id": mtch.type(int), "child": {"id": mtch.any()}} == {
-        "id": 1,
-        "child": {"id": 2},
+
+def test_logical_operators_and_invert() -> None:
+    number = mtch.type(int) | (mtch.type(str) & mtch.regex(r"\d+"))
+    assert number == 789
+    assert number == "789"
+    assert ~mtch.type(int) == "foo"
+    assert ~(mtch.type(int) & mtch.regex(r"\d+")) == 1
+
+
+def test_nested_data_structures() -> None:
+    matcher = {
+        "id": mtch.type(int),
+        "items": [
+            {"value": mtch.regex(r"^x"), "meta": mtch.any()},
+            mtch.type(float),
+        ],
     }
+    data = {"id": 1, "items": [{"value": "xyz", "meta": {}}, 1.5]}
+    assert matcher == data
 
 
-def test_matcher_keeps_value() -> None:
+def test_persistent_matcher_keeps_value() -> None:
     user_id = mtch.eq()
     assert {"id": 1, "child": {"id": 2}} != {"id": user_id, "child": {"id": user_id}}
     assert {"id": 1, "child": {"id": 1}} == {"id": user_id, "child": {"id": user_id}}
@@ -35,3 +51,20 @@ def test_persistent_matcher_repr() -> None:
     matcher = mtch.eq()
     assert matcher == "foo"
     assert repr(matcher) == "PersistentMatcher(value='foo')"
+
+
+def test_matchers_in_mock_call_args() -> None:
+    mock = Mock()
+    mock("foo", {"id": 1})
+
+    expected = call(mtch.regex("f.o"), {"id": mtch.type(int)})
+    assert mock.call_args == expected
+
+
+def test_call_args_list_with_matchers() -> None:
+    mock = Mock()
+    mock(1)
+    mock("bar")
+
+    expected = [call(mtch.type(int)), call(mtch.regex("ba."))]
+    assert mock.call_args_list == expected


### PR DESCRIPTION
## Summary
- expand test coverage
- check nested data structures
- use mock call helpers

## Testing
- `pre-commit run --files tests/test_matchers.py mtchrs/matchers.py mtchrs/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843eece621c8321afdab147c655bfa1