### PR TITLE
Improve docs for common matcher use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 [![build](https://github.com/angru/mtchrs/actions/workflows/lint-and-test.yml/badge.svg)](https://github.com/angru/mtchrs/actions/workflows/lint-and-test.yml)
 [![codecov](https://codecov.io/gh/angru/mtchrs/graph/badge.svg?token=HWB0SS88F0)](https://codecov.io/gh/angru/mtchrs)
 
+`mtchrs` provides composable matchers that can be nested inside any data structure. Use them in tests where values like database IDs or UUIDs change between runs. Matchers also integrate with `unittest.mock` assertions such as `call_args_list` for verifying mock calls.
+
 ### Documentation
 See the [documentation](https://angru.github.io/mtchrs/) for more details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # mtchrs
 
-`mtchrs` provides small, composable matchers for validating values in tests and data structures.
+`mtchrs` provides small, composable matchers for validating values in tests and data structures. It is particularly useful when your code returns values that change from run to run, such as database generated IDs or UUIDs. Matchers can be nested inside dictionaries or lists and even used in `unittest.mock` assertions.
 
 ## Installation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,3 +52,40 @@ assert number == "456"
 ```
 
 Matchers can also be used inside dictionaries or other containers for nested comparisons.
+
+## Nested data structures
+
+Matchers can be mixed into lists or dictionaries to validate complex results without checking every value exactly.
+
+```python
+matcher = {
+    "id": mtch.type(int),
+    "items": [
+        {"value": mtch.regex(r"^x"), "meta": mtch.any()},
+        mtch.type(float),
+    ],
+}
+data = {"id": 1, "items": [{"value": "xyz", "meta": {}}, 1.5]}
+assert matcher == data
+```
+
+## Mock call assertions
+
+`Matcher` instances work with `unittest.mock` and pytest helpers. They can be used to assert against `call_args` or `call_args_list` when exact values vary.
+
+```python
+from unittest.mock import Mock, call
+
+mock = Mock()
+mock("foo", {"id": 1})
+
+expected = call(mtch.regex("f.o"), {"id": mtch.type(int)})
+assert mock.call_args == expected
+
+mock = Mock()
+mock(1)
+mock("bar")
+
+expected = [call(mtch.type(int)), call(mtch.regex("ba."))]
+assert mock.call_args_list == expected
+```


### PR DESCRIPTION
## Summary
- mention nested data and mock call assertions in README
- document unpredictable values in the intro
- explain nested data structures usage
- show `call_args` and `call_args_list` examples

## Testing
- `pre-commit run --files docs/usage.md docs/index.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f46119d48321bd3e20019762ef2f