### PR TITLE
Highlight persistent matcher use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,8 @@
 
 `mtchrs` provides composable matchers that can be nested inside any data structure. Use them in tests where values like database IDs or UUIDs change between runs. Matchers also integrate with `unittest.mock` assertions such as `call_args_list` for verifying mock calls.
 
+The persistent matcher `mtch.eq()` is especially handy for tracking values that
+must stay identical across nested results or several steps of a workflow.
+
 ### Documentation
 See the [documentation](https://angru.github.io/mtchrs/) for more details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,8 @@ id_matcher = mtch.eq()
 assert {"id": 1, "child": {"id": 1}} == {"id": id_matcher, "child": {"id": id_matcher}}
 ```
 
+`mtch.eq()` remembers the first value it matches, making it ideal for verifying
+repeated IDs or tokens that must remain the same across a complex result or a
+series of operations.
+
 See the [Usage](usage.md) page for details on available matchers.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,6 +37,37 @@ assert m == "foo"
 assert m == "foo"  # subsequent comparisons must match
 ```
 
+Persistent matchers shine when you need to assert that the *same* value appears
+multiple times. Some handy scenarios include:
+
+* **Repeated identifiers in nested objects** – capture an ID once and ensure it
+  matches everywhere else in the response.
+* **Tokens shared across multi-step operations** – store a session token from
+  one request and verify it is reused in later calls.
+* **Mock call sequences** – check that the exact argument value is passed to
+  different functions or multiple calls of the same mock.
+
+For example:
+
+```python
+from unittest.mock import Mock, call
+
+user_id = mtch.eq()
+assert {"id": 1, "child": {"id": 1}} == {"id": user_id, "child": {"id": user_id}}
+
+token = mtch.eq()
+assert {"token": "abc"} == {"token": token}
+assert {"auth": "abc"} == {"auth": token}
+
+mock = Mock()
+mock(user_id)
+mock(user_id)
+assert mock.call_args_list == [call(user_id), call(user_id)]
+
+bad = {"id": 1, "child": {"id": 2}}
+assert bad != {"id": user_id, "child": {"id": user_id}}
+```
+
 ## Combining matchers
 
 Matchers support logical operators:


### PR DESCRIPTION
## Summary
- document persistent matcher `mtch.eq()` use cases
- note the matcher in README and quickstart
- add code examples and a negative case in usage docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843f64a05088321b0603239831d9ad2