### PR TITLE
Add predicate matcher

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ from mtchrs.matchers import mtch
 assert mtch.any() == 123
 assert mtch.type(int) == 42
 assert mtch.regex(r"\d+") == "456"
+assert mtch.pred(lambda v: v > 0, "positive") == 1
 
 id_matcher = mtch.eq()
 assert {"id": 1, "child": {"id": 1}} == {"id": id_matcher, "child": {"id": id_matcher}}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,18 @@ Matches a string against a regular expression.
 assert mtch.regex(r"\d+") == "123"
 ```
 
+## `mtch.pred`
+
+Create a matcher from a custom predicate function.
+
+```python
+def is_even(value: int) -> bool:
+    return value % 2 == 0
+
+assert mtch.pred(is_even) == 2
+assert mtch.pred(lambda v: v > 0, "positive") == 3
+```
+
 ## `mtch.eq`
 
 Creates a persistent matcher that remembers the first value it was compared with and requires subsequent comparisons to match that value.

--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -53,6 +53,21 @@ class Matcher:
             lambda: f"{compiled}",
         )
 
+    @staticmethod
+    def pred(predicate: t.Callable[[t.Any], bool], name: str | None = None) -> Matcher:
+        """Create a matcher from a custom predicate.
+
+        Args:
+            predicate: Callable returning ``True`` when the value matches.
+            name: Optional representation used for ``repr``. Defaults to the
+                predicate's ``__name__`` when available.
+        """
+
+        repr_str = (
+            name if name is not None else getattr(predicate, "__name__", "<predicate>")
+        )
+        return Matcher(predicate, lambda: f"pred({repr_str})")
+
 
 class PersistentMatcher(Matcher):
     _no_value = object()

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -10,6 +10,16 @@ def test_basic_matchers() -> None:
     assert mtch.regex(r"\d+") == "42"
 
 
+def test_predicate_matcher() -> None:
+    def is_even(value: int) -> bool:
+        return value % 2 == 0
+
+    assert mtch.pred(is_even) == 2
+    positive = mtch.pred(lambda v: v > 0, "positive")
+    assert positive == 1
+    assert repr(mtch.pred(is_even)) == "pred(is_even)"
+
+
 def test_logical_operators_and_invert() -> None:
     number = mtch.type(int) | (mtch.type(str) & mtch.regex(r"\d+"))
     assert number == 789


### PR DESCRIPTION
## Summary
- add `mtch.pred` to create matchers from custom predicates
- document new predicate matcher in docs
- show predicate matcher in quickstart example
- test predicate matcher

## Testing
- `pre-commit run --files mtchrs/matchers.py docs/usage.md docs/index.md tests/test_matchers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fbe276448321b41eb0f1af8fbcf6