### PR TITLE
Improve documentation and matcher docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,37 @@
 
 `mtchrs` provides composable matchers that can be nested inside any data structure. Use them in tests where values like database IDs or UUIDs change between runs. Matchers also integrate with `unittest.mock` assertions such as `call_args_list` for verifying mock calls.
 
-The persistent matcher `mtch.eq()` is especially handy for tracking values that
-must stay identical across nested results or several steps of a workflow.
+The persistent matcher `mtch.eq()` is especially handy for tracking values that must stay identical across nested results or several steps of a workflow.
+
+## Installation
+
+```bash
+pip install mtchrs
+```
+
+## Example
+
+```python
+from mtchrs.matchers import mtch
+
+data = {"id": 1, "items": ["xyz", 1.5]}
+matcher = {"id": mtch.type(int), "items": [mtch.regex(r"^x"), mtch.type(float)]}
+assert matcher == data
+```
+
+## Contributing
+
+Pull requests are welcome! Install dependencies from the `dev`, `lint` and `test` groups and run the linters and test suite before submitting a PR:
+
+```bash
+pip install -e .[dev,lint,test]
+pre-commit run --all-files
+pytest
+```
+
+## License
+
+This project is licensed under the MIT License.
 
 ### Documentation
 See the [documentation](https://angru.github.io/mtchrs/) for more details.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ assert matcher == data
 
 ## Contributing
 
-Pull requests are welcome! Install dependencies from the `dev`, `lint` and `test` groups and run the linters and test suite before submitting a PR:
+Pull requests are welcome! Install dependencies from the `dev`, `lint` and `test` groups using [uv](https://github.com/astral-sh/uv) and run the linters and test suite before submitting a PR:
 
 ```bash
-pip install -e .[dev,lint,test]
-pre-commit run --all-files
-pytest
+uv pip install -e .[dev,lint,test]
+uv run pre-commit run --all-files
+uv run pytest
 ```
 
 ## License

--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -1,3 +1,11 @@
+"""Composable matchers for flexible equality assertions.
+
+The :class:`Matcher` class wraps a predicate used during ``==`` comparisons.
+Matchers can be combined with ``&`` and ``|`` for logical composition and
+inverted with ``~``. They work inside nested data structures and integrate with
+``unittest.mock`` for verifying mock calls.
+"""
+
 from __future__ import annotations
 
 import re
@@ -11,6 +19,7 @@ class Matcher:
     comparisons. They can be combined with ``&`` and ``|`` to build complex
     conditions or inverted with ``~``.
     """
+
     def __init__(self, func: t.Callable[[t.Any], bool], repr_func: t.Callable[[], str]):
         self._func = func
         self._repr_func = repr_func
@@ -85,6 +94,7 @@ class Matcher:
 
 class PersistentMatcher(Matcher):
     """Matcher that stores the first value it matches for future comparisons."""
+
     _no_value = object()
 
     def __init__(self):

--- a/mtchrs/matchers.py
+++ b/mtchrs/matchers.py
@@ -5,6 +5,12 @@ import typing as t
 
 
 class Matcher:
+    """Base class for value matchers.
+
+    ``Matcher`` objects wrap a predicate function used during ``==``
+    comparisons. They can be combined with ``&`` and ``|`` to build complex
+    conditions or inverted with ``~``.
+    """
     def __init__(self, func: t.Callable[[t.Any], bool], repr_func: t.Callable[[], str]):
         self._func = func
         self._repr_func = repr_func
@@ -32,14 +38,20 @@ class Matcher:
 
     @staticmethod
     def any() -> Matcher:
+        """Return a matcher that accepts any value."""
+
         return Matcher(lambda v: True, lambda: "Any")
 
     @staticmethod
     def eq() -> PersistentMatcher:
+        """Return a matcher that remembers the first value it matches."""
+
         return PersistentMatcher()
 
     @staticmethod
     def type(*types: type) -> Matcher:
+        """Match when ``value`` is an instance of ``types``."""
+
         return Matcher(
             lambda v: isinstance(v, types),
             lambda: f'Type[{" | ".join((str(t) for t in types))}]',
@@ -47,6 +59,8 @@ class Matcher:
 
     @staticmethod
     def regex(pattern: t.Union[str, re.Pattern]) -> Matcher:
+        """Match a string using ``pattern``."""
+
         compiled = re.compile(pattern) if isinstance(pattern, str) else pattern
         return Matcher(
             lambda v: isinstance(v, str) and bool(compiled.match(v)),
@@ -70,6 +84,7 @@ class Matcher:
 
 
 class PersistentMatcher(Matcher):
+    """Matcher that stores the first value it matches for future comparisons."""
     _no_value = object()
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- document all matchers with docstrings
- expand README with install example, basic usage and contribution info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684400c3ce84832183658152ffd3824d